### PR TITLE
feat: add a should_record_span predicate to ActionTraceSubscriber

### DIFF
--- a/tracing_actions/benches/benchmarks/tracing_bench.rs
+++ b/tracing_actions/benches/benchmarks/tracing_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, Criterion};
 use tracing::{metadata::LevelFilter, Instrument, Level};
 use tracing_actions::{
-    span_constructor::{AlwaysNewSpanConstructor, LazySpanCache},
+    span_constructor::{always_record, AlwaysNewSpanConstructor, LazySpanCache},
     ActionTraceSubscriber, TraceSink,
 };
 
@@ -13,7 +13,12 @@ impl TraceSink for NoSink {
 fn trace(c: &mut Criterion) {
     let mut group = c.benchmark_group("Traces");
 
-    let actions = ActionTraceSubscriber::new(LevelFilter::DEBUG, NoSink, AlwaysNewSpanConstructor);
+    let actions = ActionTraceSubscriber::new(
+        LevelFilter::DEBUG,
+        NoSink,
+        AlwaysNewSpanConstructor,
+        always_record,
+    );
 
     tracing::subscriber::with_default(actions, || {
         group.bench_function("always new span", |bencher| {
@@ -29,7 +34,12 @@ fn trace(c: &mut Criterion) {
         });
     });
 
-    let actions = ActionTraceSubscriber::new(LevelFilter::DEBUG, NoSink, LazySpanCache::default());
+    let actions = ActionTraceSubscriber::new(
+        LevelFilter::DEBUG,
+        NoSink,
+        LazySpanCache::default(),
+        always_record,
+    );
 
     tracing::subscriber::with_default(actions, || {
         group.bench_function("default span cache", |bencher| {

--- a/tracing_actions/src/lib.rs
+++ b/tracing_actions/src/lib.rs
@@ -34,6 +34,7 @@
 //!     level,
 //!     KLog { k: 42, n: Default::default() },
 //!     tracing_actions::span_constructor::LazySpanCache::default(),
+//!     tracing_actions::span_constructor::always_record,
 //! );
 //!
 //! // Finally, we install the subscriber.

--- a/tracing_actions/src/span_constructor.rs
+++ b/tracing_actions/src/span_constructor.rs
@@ -18,6 +18,10 @@ impl SpanConstructor for AlwaysNewSpanConstructor {
     }
 }
 
+pub fn always_record(_action_span: &mut ActionSpan) -> bool {
+    true
+}
+
 /// Works with shared spans when it wins a race to grab a mutex.
 /// When it doesn't get a shared span, it simply allocates a new one.
 pub struct LazySpanCache {

--- a/tracing_actions_otlp/src/lib.rs
+++ b/tracing_actions_otlp/src/lib.rs
@@ -45,6 +45,7 @@
 //!     level,
 //!     otlp_sink,
 //!     tracing_actions::span_constructor::LazySpanCache::default(),
+//!     tracing_actions::span_constructor::always_record,
 //! );
 //!
 //! // Finally, we install the subscriber.


### PR DESCRIPTION
A user may want some way to filter out recorded spans before sending
them to a `Sink`. How the user wants to determine whether an
`ActionSpan` is recorded is up to them, but this PR gives them the
ability to do such.

The simplest approach is to perform the check before we grab the mutex
and send the `ActionSpan` to the `Sink`. If the predicate returns false,
we avoid spending CPU cycles grabbing the lock and appending the span to
the end of the `Vec`. It then gets dropped from memory regardless of the
outcome (as it always has).
